### PR TITLE
Default origin to vkey name

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ go run .
 ```
 
 Features:
- - `<Ctrl-c>` to quit
+ - `q` or `<Ctrl-c>` to quit
  - Left/Right arrows: previous/next leaf
 - `l`: show the log selector to switch to a different log
 - `g`: jump to a specific leaf

--- a/main.go
+++ b/main.go
@@ -215,6 +215,10 @@ func newTLogTilesLogClient(lr string, origin string, vkey string) logClient {
 	if err != nil {
 		klog.Exit(err)
 	}
+	if len(origin) == 0 {
+		origin = verifier.Name()
+		klog.Infof("No origin provided; using verifier name: %q", origin)
+	}
 	return &tLogTilesLogClient{
 		origin:   origin,
 		verifier: verifier,

--- a/view.go
+++ b/view.go
@@ -138,6 +138,8 @@ func (v View) Run(ctx context.Context) error {
 			v.bottomArea.SwitchToPage("jump")
 			v.app.SetFocus(v.jumpPage)
 			return nil
+		case 'q':
+			v.app.Stop()
 		}
 		return event
 	})


### PR DESCRIPTION
Also make it easier to quit by adding q in addition to Ctrl-C
